### PR TITLE
Adopt stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly
+  - stable
 cache:
   - cargo
 script:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,6 @@ dependencies = [
  "pretty_env_logger 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "render-tree 0.1.1",
- "runtime-fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -250,11 +249,6 @@ dependencies = [
  "pretty_env_logger 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "runtime-fmt"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
@@ -455,7 +449,6 @@ dependencies = [
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
-"checksum runtime-fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "647a821d66049faccc993fc3c379d1181b81a484097495cda79ffdb17b55b87f"
 "checksum serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)" = "076a696fdea89c19d3baed462576b8f6d663064414b5c793642da8dfeb99475b"
 "checksum serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)" = "ef45eb79d6463b22f5f9e16d283798b7c0175ba6050bc25c1a946c122727fe7b"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ serde_derive = "1.0.94"
 structopt = "0.2.13"
 unindent = "0.1.3"
 term = "0.5.1"
-runtime-fmt = "0.3.0"
 # pretty_assertions = { git = "https://github.com/Nemo157/rust-pretty-assertions", rev = "9332632" }
 regex = "1.0.5"
 pretty_env_logger = "0.2.5"

--- a/src/components.rs
+++ b/src/components.rs
@@ -6,7 +6,7 @@ use crate::render_tree::prelude::*;
 use crate::ReportingFiles;
 use crate::{models, Location};
 
-pub(crate) fn Diagnostic(data: DiagnosticData<'args, impl ReportingFiles>, into: Document) -> Document {
+pub(crate) fn Diagnostic<'args>(data: DiagnosticData<'args, impl ReportingFiles>, into: Document) -> Document {
     let header = models::Header::new(&data.diagnostic);
 
     into.add(tree! {
@@ -35,7 +35,7 @@ pub(crate) fn Header<'args>(header: models::Header<'args>, into: Document) -> Do
     })
 }
 
-pub(crate) fn Body(data: DiagnosticData<'args, impl ReportingFiles>, mut into: Document) -> Document {
+pub(crate) fn Body<'args>(data: DiagnosticData<'args, impl ReportingFiles>, mut into: Document) -> Document {
     for label in &data.diagnostic.labels {
         let source_line = models::SourceLine::new(data.files, label, data.config);
         let labelled_line = models::LabelledLine::new(source_line.clone(), label);
@@ -71,7 +71,7 @@ pub(crate) fn SourceCodeLocation(
     })
 }
 
-pub(crate) fn SourceCodeLine(
+pub(crate) fn SourceCodeLine<'args>(
     model: models::LabelledLine<'args, impl ReportingFiles>,
     into: Document,
 ) -> Document {

--- a/src/components.rs
+++ b/src/components.rs
@@ -6,7 +6,7 @@ use crate::render_tree::prelude::*;
 use crate::ReportingFiles;
 use crate::{models, Location};
 
-crate fn Diagnostic(data: DiagnosticData<'args, impl ReportingFiles>, into: Document) -> Document {
+pub(crate) fn Diagnostic(data: DiagnosticData<'args, impl ReportingFiles>, into: Document) -> Document {
     let header = models::Header::new(&data.diagnostic);
 
     into.add(tree! {
@@ -17,7 +17,7 @@ crate fn Diagnostic(data: DiagnosticData<'args, impl ReportingFiles>, into: Docu
     })
 }
 
-crate fn Header<'args>(header: models::Header<'args>, into: Document) -> Document {
+pub(crate) fn Header<'args>(header: models::Header<'args>, into: Document) -> Document {
     into.add(tree! {
         <Section name="header" as {
             <Line as {
@@ -35,7 +35,7 @@ crate fn Header<'args>(header: models::Header<'args>, into: Document) -> Documen
     })
 }
 
-crate fn Body(data: DiagnosticData<'args, impl ReportingFiles>, mut into: Document) -> Document {
+pub(crate) fn Body(data: DiagnosticData<'args, impl ReportingFiles>, mut into: Document) -> Document {
     for label in &data.diagnostic.labels {
         let source_line = models::SourceLine::new(data.files, label, data.config);
         let labelled_line = models::LabelledLine::new(source_line.clone(), label);
@@ -53,7 +53,7 @@ crate fn Body(data: DiagnosticData<'args, impl ReportingFiles>, mut into: Docume
     into
 }
 
-crate fn SourceCodeLocation(
+pub(crate) fn SourceCodeLocation(
     source_line: models::SourceLine<impl ReportingFiles>,
     into: Document,
 ) -> Document {
@@ -71,7 +71,7 @@ crate fn SourceCodeLocation(
     })
 }
 
-crate fn SourceCodeLine(
+pub(crate) fn SourceCodeLine(
     model: models::LabelledLine<'args, impl ReportingFiles>,
     into: Document,
 ) -> Document {

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -32,7 +32,7 @@ impl<W> DiagnosticWriter<W>
 where
     W: WriteColor,
 {
-    fn emit(mut self, data: DiagnosticData<'doc, impl ReportingFiles>) -> io::Result<()> {
+    fn emit<'doc>(mut self, data: DiagnosticData<'doc, impl ReportingFiles>) -> io::Result<()> {
         let document = Component(components::Diagnostic, data).into_fragment();
 
         let styles = Stylesheet::new()

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -69,10 +69,10 @@ impl Config for DefaultConfig {
 }
 
 #[derive(Debug)]
-crate struct DiagnosticData<'doc, Files: ReportingFiles> {
-    crate files: &'doc Files,
-    crate diagnostic: &'doc Diagnostic<Files::Span>,
-    crate config: &'doc dyn Config,
+pub(crate) struct DiagnosticData<'doc, Files: ReportingFiles> {
+    pub(crate) files: &'doc Files,
+    pub(crate) diagnostic: &'doc Diagnostic<Files::Span>,
+    pub(crate) config: &'doc dyn Config,
 }
 
 pub fn format(f: impl Fn(&mut fmt::Formatter) -> fmt::Result) -> impl fmt::Display {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![recursion_limit = "1024"]
-#![feature(in_band_lifetimes)]
 
 #[macro_use]
 extern crate render_tree;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![recursion_limit = "1024"]
-#![feature(trace_macros, crate_visibility_modifier, in_band_lifetimes)]
+#![feature(trace_macros, in_band_lifetimes)]
 
 #[macro_use]
 extern crate render_tree;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![recursion_limit = "1024"]
-#![feature(trace_macros, in_band_lifetimes)]
+#![feature(in_band_lifetimes)]
 
 #[macro_use]
 extern crate render_tree;

--- a/src/models.rs
+++ b/src/models.rs
@@ -53,7 +53,7 @@ pub(crate) struct SourceLine<'doc, Files: ReportingFiles> {
     config: &'doc dyn crate::Config,
 }
 
-impl<Files: ReportingFiles> SourceLine<'doc, Files> {
+impl<'doc, Files: ReportingFiles> SourceLine<'doc, Files> {
     pub(crate) fn new(
         files: &'doc Files,
         label: &'doc Label<Files::Span>,
@@ -128,7 +128,7 @@ pub struct LabelledLine<'doc, Files: ReportingFiles> {
     label: &'doc Label<Files::Span>,
 }
 
-impl<Files: ReportingFiles> LabelledLine<'doc, Files> {
+impl<'doc, Files: ReportingFiles> LabelledLine<'doc, Files> {
     pub(crate) fn new(
         source_line: SourceLine<'doc, Files>,
         label: &'doc Label<Files::Span>,

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,14 +2,14 @@ use crate::diagnostic::Diagnostic;
 use crate::{FileName, Label, LabelStyle, Location, ReportingFiles, ReportingSpan, Severity};
 
 #[derive(Copy, Clone, Debug)]
-crate struct Header<'doc> {
+pub(crate) struct Header<'doc> {
     severity: Severity,
     code: Option<&'doc str>,
     message: &'doc str,
 }
 
 impl<'doc> Header<'doc> {
-    crate fn new(diagnostic: &'doc Diagnostic<impl ReportingSpan>) -> Header<'doc> {
+    pub(crate) fn new(diagnostic: &'doc Diagnostic<impl ReportingSpan>) -> Header<'doc> {
         Header {
             severity: diagnostic.severity,
             code: diagnostic.code.as_ref().map(|c| &c[..]),
@@ -17,7 +17,7 @@ impl<'doc> Header<'doc> {
         }
     }
 
-    crate fn severity(&self) -> &'static str {
+    pub(crate) fn severity(&self) -> &'static str {
         match self.severity {
             Severity::Bug => "bug",
             Severity::Error => "error",
@@ -27,16 +27,16 @@ impl<'doc> Header<'doc> {
         }
     }
 
-    crate fn code(&self) -> &Option<&'doc str> {
+    pub(crate) fn code(&self) -> &Option<&'doc str> {
         &self.code
     }
 
-    crate fn message(&self) -> String {
+    pub(crate) fn message(&self) -> String {
         self.message.to_string()
     }
 }
 
-crate fn severity(diagnostic: &Diagnostic<impl ReportingSpan>) -> &'static str {
+pub(crate) fn severity(diagnostic: &Diagnostic<impl ReportingSpan>) -> &'static str {
     match diagnostic.severity {
         Severity::Bug => "bug",
         Severity::Error => "error",
@@ -47,14 +47,14 @@ crate fn severity(diagnostic: &Diagnostic<impl ReportingSpan>) -> &'static str {
 }
 
 #[derive(Copy, Clone, Debug)]
-crate struct SourceLine<'doc, Files: ReportingFiles> {
+pub(crate) struct SourceLine<'doc, Files: ReportingFiles> {
     files: &'doc Files,
     label: &'doc Label<Files::Span>,
     config: &'doc dyn crate::Config,
 }
 
 impl<Files: ReportingFiles> SourceLine<'doc, Files> {
-    crate fn new(
+    pub(crate) fn new(
         files: &'doc Files,
         label: &'doc Label<Files::Span>,
         config: &'doc dyn crate::Config,
@@ -66,7 +66,7 @@ impl<Files: ReportingFiles> SourceLine<'doc, Files> {
         }
     }
 
-    crate fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         let span = self.label.span;
 
         self.files
@@ -74,7 +74,7 @@ impl<Files: ReportingFiles> SourceLine<'doc, Files> {
             .expect("A valid location")
     }
 
-    crate fn filename(&self) -> String {
+    pub(crate) fn filename(&self) -> String {
         match &self.files.file_name(self.files.file_id(self.label.span)) {
             FileName::Virtual(name) => format!("<{}>", name.to_str().unwrap()),
             FileName::Real(name) => self.config.filename(name),
@@ -82,7 +82,7 @@ impl<Files: ReportingFiles> SourceLine<'doc, Files> {
         }
     }
 
-    crate fn line_span(&self) -> Files::Span {
+    pub(crate) fn line_span(&self) -> Files::Span {
         let span = self.label.span;
 
         self.files
@@ -90,26 +90,26 @@ impl<Files: ReportingFiles> SourceLine<'doc, Files> {
             .expect("line_span")
     }
 
-    crate fn line_number(&self) -> usize {
+    pub(crate) fn line_number(&self) -> usize {
         self.location().line + 1
     }
 
-    crate fn line_number_len(&self) -> usize {
+    pub(crate) fn line_number_len(&self) -> usize {
         self.line_number().to_string().len()
     }
 
-    // crate fn before_line_len(&self) -> usize {
+    // pub(crate) fn before_line_len(&self) -> usize {
     //     // TODO: Improve
     //     self.before_marked().len() + self.line_number().to_string().len()
     // }
 
-    crate fn before_marked(&self) -> String {
+    pub(crate) fn before_marked(&self) -> String {
         self.files
             .source(self.line_span().with_end(self.label.span.start()))
             .expect("line_prefix")
     }
 
-    crate fn after_marked(&self) -> String {
+    pub(crate) fn after_marked(&self) -> String {
         self.files
             .source(self.line_span().with_start(self.label.span.end()))
             .expect("line_suffix")
@@ -117,7 +117,7 @@ impl<Files: ReportingFiles> SourceLine<'doc, Files> {
             .to_string()
     }
 
-    crate fn marked(&self) -> String {
+    pub(crate) fn marked(&self) -> String {
         self.files.source(self.label.span).expect("line_marked")
     }
 }
@@ -129,32 +129,32 @@ pub struct LabelledLine<'doc, Files: ReportingFiles> {
 }
 
 impl<Files: ReportingFiles> LabelledLine<'doc, Files> {
-    crate fn new(
+    pub(crate) fn new(
         source_line: SourceLine<'doc, Files>,
         label: &'doc Label<Files::Span>,
     ) -> LabelledLine<'doc, Files> {
         LabelledLine { source_line, label }
     }
 
-    crate fn mark(&self) -> &'static str {
+    pub(crate) fn mark(&self) -> &'static str {
         match self.label.style {
             LabelStyle::Primary => "^",
             LabelStyle::Secondary => "-",
         }
     }
 
-    crate fn style(&self) -> &'static str {
+    pub(crate) fn style(&self) -> &'static str {
         match self.label.style {
             LabelStyle::Primary => "primary",
             LabelStyle::Secondary => "secondary",
         }
     }
 
-    crate fn message(&self) -> &Option<String> {
+    pub(crate) fn message(&self) -> &Option<String> {
         self.label.message()
     }
 
-    crate fn source_line(&self) -> &SourceLine<'doc, Files> {
+    pub(crate) fn source_line(&self) -> &SourceLine<'doc, Files> {
         &self.source_line
     }
 }


### PR DESCRIPTION
This ports `language-reporting` to stable Rust.

Needed for https://github.com/nushell/nushell/issues/362